### PR TITLE
Change dockerfile build strategy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,98 @@
+# Git
+.git
+.gitignore
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+.docker
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*/__pycache__/
+*/*/__pycache__/
+*/*/*/__pycache__/
+*.py[cod]
+*/*.py[cod]
+*/*/*.py[cod]
+*/*/*/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env/
+.venv/
+venv/
+
+# IDEs
+.idea
+.vscode
+.devcontainer
+
+# Python mode for VIM
+.ropeproject
+*/.ropeproject
+*/*/.ropeproject
+*/*/*/.ropeproject
+
+# Vim swap files
+*.swp
+*/*.swp
+*/*/*.swp
+*/*/*/*.swp
+
+# GitHub Actions
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,20 @@ ENV PATH=/root/.local/bin:$PATH
 
 ENV PYTHONPATH=/app
 
+WORKDIR /app
+
 RUN pip install --upgrade pip \
   && pip install pipenv flask gunicorn
 
-COPY . /app
-WORKDIR /app
+COPY Pipfile .
+COPY Pipfile.lock .
+COPY requirements.txt .
+
 # First we get the dependencies for the stack itself
 RUN pipenv lock -r > requirements.txt
 RUN pip install -r requirements.txt
+
+COPY . /app
+
 EXPOSE 5000
 CMD ["gunicorn", "-w 4", "-b 0.0.0.0:5000", "app:app"]


### PR DESCRIPTION
I've changed the order of some actions in this Dockerfile in order to improve build times.

The proposed strategy consists on:

* Install dependencies
* Copy the app
* Run it

Like this, provided that the dependencies don't change, these will be stored in a layer on your Docker engine local registry. This means that modifying the app content / logic will only affect the bottommost layers. Should the dependencies change, all layers will need rebuilding, but since dependencies don't change often, this change will decrease build time for most cases.