### PR TITLE
Serve UI from python backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,98 @@
+# Git
+.git
+.gitignore
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+.docker
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*/__pycache__/
+*/*/__pycache__/
+*/*/*/__pycache__/
+*.py[cod]
+*/*.py[cod]
+*/*/*.py[cod]
+*/*/*/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env/
+.venv/
+venv/
+
+# IDEs
+.idea
+.vscode
+.devcontainer
+
+# Python mode for VIM
+.ropeproject
+*/.ropeproject
+*/*/.ropeproject
+*/*/*/.ropeproject
+
+# Vim swap files
+*.swp
+*/*.swp
+*/*/*.swp
+*/*/*/*.swp
+
+# GitHub Actions
+.github

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,10 @@
 docker-compose.yml
 .docker
 
+# Node
+node_modules
+npm-debug.log
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 */__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+FROM node:12 AS frontend
+
+WORKDIR /usr/src/app
+
+COPY ./ui/package.json ./
+COPY ./ui/yarn.lock ./
+
+RUN yarn install
+
+COPY ./ui .
+
+RUN yarn build
+
+
 FROM python:3.7.4-stretch
 ENV PATH=/root/.local/bin:$PATH
 
@@ -17,6 +31,7 @@ RUN pipenv lock -r > requirements.txt
 RUN pip install -r requirements.txt
 
 COPY . /app
+COPY --from=frontend /usr/src/app/dist /app/api/dist/
 
 EXPOSE 5000
 CMD ["gunicorn", "-w 4", "-b 0.0.0.0:5000", "app:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,20 @@ ENV PATH=/root/.local/bin:$PATH
 
 ENV PYTHONPATH=/app
 
+WORKDIR /app
+
 RUN pip install --upgrade pip \
   && pip install pipenv flask gunicorn
 
-COPY . /app
-WORKDIR /app
+COPY Pipfile .
+COPY Pipfile.lock .
+COPY requirements.txt .
+
 # First we get the dependencies for the stack itself
 RUN pipenv lock -r > requirements.txt
 RUN pip install -r requirements.txt
+
+COPY . /app
+
 EXPOSE 5000
 CMD ["gunicorn", "-w 4", "-b 0.0.0.0:5000", "app:app"]

--- a/api/uispa.py
+++ b/api/uispa.py
@@ -3,7 +3,7 @@ from flask import Blueprint,render_template
 ui_blueprint = Blueprint("ui-spa", __name__,
     template_folder='dist',
     static_folder='dist',
-    static_url_path='/ui/'
+    static_url_path='/'
 )
 
 @ui_blueprint.route("/home")

--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ app = Flask(__name__)
 app.register_blueprint(control_blueprint)
 app.register_blueprint(health_blueprint)
 app.register_blueprint(metrics_blueprint)
-# app.register_blueprint(ui_blueprint)
+app.register_blueprint(ui_blueprint)
 swagger = Swagger(app, template=swagger_template)
 
 # It is considered bad form to return an error for '/', so let's redirect to the apidocs


### PR DESCRIPTION
I've enabled serving the frontend from the python backend. The Dockerfile is multistage in order to avoid having the `node_modules` folder on the final container (this reduces its size).